### PR TITLE
fix: changed shebang to make scripts more platform independent

### DIFF
--- a/zshMusic.zsh
+++ b/zshMusic.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 dir="$(dirname "${0:A}")/appleScripts"
 


### PR DESCRIPTION
Not all environments have ZSH at a place you might expect. Various environments do not have ZSH at `/bin/zsh`. For example NixOS has it in the nix store. I heard this also wouldn't work on BSD for similar reasons, but don't quote me on that.


See for example [this thread](https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash) on the argumentation on why it is best practice. That discussion is mostly about why its better to use `#!/usr/bin/env bash` instead of `#!/bin/bash`, but the arguments apply to all programs you might wanna put in the shebang. 

Without this change these scripts will not run on some platforms for example NixOS. This is **not** a breaking change for the platforms it already currently works on.