### PR TITLE
feat: add query command to search and play songs

### DIFF
--- a/appleScripts/query.applescript
+++ b/appleScripts/query.applescript
@@ -1,0 +1,37 @@
+on run argv
+    set searchQuery to item 1 of argv
+    
+    tell application "Music"
+        try
+            set searchResults to search playlist "Library" for searchQuery
+            
+            if (count of searchResults) > 0 then
+                set output to "Found " & (count of searchResults) & " result(s) for '" & searchQuery & "':" & return & return
+                
+                -- Store the first track to play it
+                set firstTrack to item 1 of searchResults
+                
+                repeat with i from 1 to count of searchResults
+                    set theTrack to item i of searchResults
+                    set trackInfo to (i as string) & ". " & name of theTrack & " - " & artist of theTrack & " (" & album of theTrack & ")"
+                    set output to output & trackInfo & return
+                    
+                    if i >= 10 then
+                        set output to output & return & "... and " & ((count of searchResults) - 10) & " more result(s)"
+                        exit repeat
+                    end if
+                end repeat
+                
+                -- Play the first/best match
+                play firstTrack
+                set output to output & return & "▶ Now playing: " & name of firstTrack & " - " & artist of firstTrack
+                
+                return output
+            else
+                return "No results found for '" & searchQuery & "'"
+            end if
+        on error errMsg
+            return "Error searching: " & errMsg
+        end try
+    end tell
+end run

--- a/zshMusic.zsh
+++ b/zshMusic.zsh
@@ -36,6 +36,13 @@ music() {
       -current | -c)
         osascript $dir/current.applescript "$2"
         ;;
+      -query | -q)
+        if [[ -z $2 ]]; then
+          echo "You need to pass a search query"
+        else
+          osascript $dir/query.applescript "$2"
+        fi
+        ;;
       -help | -h)
         help
         ;;
@@ -92,6 +99,11 @@ cmd7="-c"
 des7="Shows current track"
 ex7="music -c"
 
+com8="-query"
+cmd8="-q"
+des8="Search for songs"
+ex8="music -q 'Song Name'"
+
 
 echo ''
 echo "  ;;;;;; ███████ ███████ ██   ██ ███    ███ ██    ██ ███████ ██  ██████ "
@@ -122,5 +134,7 @@ sleep 0.01
 printf "%-10s %-5s %-25s %-10s\n" "$com6" "$cmd6" "$des6" "$ex6"
 sleep 0.01
 printf "%-10s %-5s %-25s %-10s\n" "$com7" "$cmd7" "$des7" "$ex7"
+sleep 0.01
+printf "%-10s %-5s %-25s %-10s\n" "$com8" "$cmd8" "$des8" "$ex8"
 sleep 0.01
 }


### PR DESCRIPTION
Add new -query/-q command that searches the Music library for songs matching a query string and automatically plays the best match.

Example usage: music -q 'Song Name'