### PR TITLE
feat: add not found error for invalid artist with -a flag

### DIFF
--- a/appleScripts/playArtist.applescript
+++ b/appleScripts/playArtist.applescript
@@ -15,7 +15,7 @@ tell application "Music"
 	end if
 	set artistTracks to (every track of library playlist 1 whose artist is artistName)
 	if (count of artistTracks) is 0 then
-		return "No tracks found from artist: " & artistName
+		return "No tracks found from " & artistName
 	end if
 	delete every track of artistPlaylist
 	repeat with aTrack in artistTracks

--- a/appleScripts/playArtist.applescript
+++ b/appleScripts/playArtist.applescript
@@ -14,7 +14,10 @@ tell application "Music"
 		set artistPlaylist to (make new playlist with properties {name:playlistName})
 	end if
 	delete every track of artistPlaylist
-	set artistTracks to (every track of library playlist 1 whose artist is artistName)
+    set artistTracks to (every track of library playlist 1 whose artist is artistName)
+    if (count of artistTracks) is 0 then
+        error "No tracks found for artist: " & artistName
+    end if
 	repeat with aTrack in artistTracks
 		duplicate aTrack to artistPlaylist
 	end repeat

--- a/appleScripts/playArtist.applescript
+++ b/appleScripts/playArtist.applescript
@@ -13,11 +13,11 @@ tell application "Music"
 	if artistPlaylist is null then
 		set artistPlaylist to (make new playlist with properties {name:playlistName})
 	end if
+	set artistTracks to (every track of library playlist 1 whose artist is artistName)
+	if (count of artistTracks) is 0 then
+		return "No tracks found from artist: " & artistName
+	end if
 	delete every track of artistPlaylist
-    set artistTracks to (every track of library playlist 1 whose artist is artistName)
-    if (count of artistTracks) is 0 then
-        error "No tracks found for artist: " & artistName
-    end if
 	repeat with aTrack in artistTracks
 		duplicate aTrack to artistPlaylist
 	end repeat


### PR DESCRIPTION
I tried using the flag `-a` and didn't get an explicit error:

```sh
music -a "Marc DeMarco"
.../playArtist.applescript:696:715: execution error: Music got an error: Parameter error. (-50)
```

My first intuition was to check if there are some outdated applescript files, then I figured out that I just misspelled the artists name.

After a quick fix, now the music that is already being played doesn't stop because of the error and a message is returned to the user:

```sh
music -a "Marc DeMarco"
No tracks found from Marc DeMarco
```